### PR TITLE
v1.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-DB Typegen sauce 
+DB Typegen sauce
 
 ## Prerequisite
 
@@ -14,20 +14,42 @@ Install dependencies
 ## Project structure
 
 deps - Dependency packages
+src - Main db-typegen package
 
 # How to
-- Test changes
-  - `npm run build`
-  - `npx ts-node 'path/datasource/index.ts'`
-    - example: `npx ts-node '__typegen__/postgresql/index.ts`
 
+- Test changes
+
+  - `npm run generate` // This will generate the `index.ts` and related files
+  - `npx ts-node 'path/datasource/index.ts'`
+    - example: `npx ts-node __typegen__/postgresql/index.ts`
+
+- Submit pull request
+  - Don't forget to update [https://github.com/chrischanF/db-typegen/tree/main/src](db-typegen README)
+
+**See** [https://github.com/chrischanF/db-typegen/tree/main/src](db-typegen README) for more
 
 ## Changelog
 
+**1.1.7**
+
+- Added double quote delimiter for tables to avoid clashing with postgresql reserved words
+- Removed `insert`, `update` and `delete` client schema check
+- Improved `experimentalResolver` typings
+- Improved `relationships` resolvers return types
+- Improved `insert` statement return type
+  - Introduced `PGInsertResult<T> - { insertedCount: number; data: T[] }`
+- Improved `update` statement return type
+  - Introduced `PGUpdateResult<T> - { updatedCount: number; data: T[] }`
+- Improved `delete` statement return type
+  - Introduced `PGDeleteResult<T> - { deletedCount: number }`
+- Fixed `db-typegen-utils` import path
+- Fixed undefined error on generate
 
 **1.1.2**
+
 - Removed default query logging
-  - Though still shows when `FindOptionsPG.debug` is `true`
+  - Though still shows when `PGFindOptions.debug` is `true`
 - Fixed `experimentalResolver` methods `filter` args not working
   - Currently supports `=` by default
 

--- a/deps/db-typegen-utils/package.json
+++ b/deps/db-typegen-utils/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "db-typegen-utils",
-  "version": "1.0.0",
   "description": "db-typegen package utils",
   "scripts": {
     "build": "rm -rf dist && tsc && npm run cp:package.json",

--- a/deps/db-typegen-utils/src/index.ts
+++ b/deps/db-typegen-utils/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/mongodb';
 export * from './lib/postgres';
+export * from './lib/shared';

--- a/deps/db-typegen-utils/src/lib/shared.ts
+++ b/deps/db-typegen-utils/src/lib/shared.ts
@@ -1,0 +1,3 @@
+export interface AnyObject {
+  [key: string]: any;
+}

--- a/deps/db-typegen-utils/src/package.json
+++ b/deps/db-typegen-utils/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "db-typegen-utils",
-  "version": "1.0.3",
+  "version": "1.0.7",
   "description": " db-typegen package utils",
   "scripts": {},
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "db-typegen",
   "version": "1.0.0",
   "description": "PostgreSQL typescript code generator",
   "author": {

--- a/src/README.md
+++ b/src/README.md
@@ -87,32 +87,32 @@ This document outlines the configuration schema for the `typegen.config.json` fi
 
 ## Configuration Schema
 
-| Key                                          | Type       | Description                                                                        |
-| -------------------------------------------- | ---------- | ---------------------------------------------------------------------------------- |
-| `architecture`                               | `string`   | Programming style: 'class' or 'functional'.                                        |
-| `format`                                     | `string`   | Naming Convention 'camelCase' or 'snake_case'.                                     |
-| `experimentalResolvers`                      | `boolean`  | Creates methods for every table columns: true or false                             |
-| `prettier`                                   | `boolean`  | Format generated code: true or false                                               |
-| `splitTypings`                               | `boolean`  | Abstract types and interfaces in the `types.ts` file: true or false                |
-| `postgresql`                                 | `object`   | PostgreSQL database configuration.                                                 |
-| `postgresql`.`schemas` (New v1.1)            | `string[]` | Specific schema to generate: ["table_one", "table_two"]                            |
-| `postgresql`.`dbConfig`                      | `object`   | Configuration settings for PostgreSQL database connection: {}                      |
-| `postgresql`.`dbConfig`.`user`               | `string`   | Database user: 'postgres'                                                          |
-| `postgresql`.`dbConfig`.`host`               | `string`   | Database host: 'localhost'                                                         |
-| `postgresql`.`dbConfig`.`database`           | `string`   | Database name: ''                                                                  |
-| `postgresql`.`dbConfig`.`password`           | `string`   | Database password: 'password'                                                      |
-| `postgresql`.`dbConfig`.`port`               | `integer`  | Database port: 5432                                                                |
-| `postgresql`.`path`                          | `string`   | Directory to save the generated files: './src/**typegen**/postgresql'              |
-| `postgresql`.`experimentals`                 | `object`   | Experimental features for PostgreSQL: {}                                           |
-| `postgresql`.`experimentals`.`relationships` | `boolean`  | Include tables constraints / relationships for the `select` methods: true or false |
-| `mongodb`                                    | `object`   | MongoDB database configuration.                                                    |
-| `mongodb`.`dbConfig`                         | `object`   | Configuration settings for MongoDB database connection: {}                         |
-| `mongodb`.`dbConfig`.`host`                  | `string`   | Database host: 'localhost'                                                         |
-| `mongodb`.`dbConfig`.`database`              | `string`   | Database name: ''                                                                  |
-| `mongodb`.`dbConfig`.`port`                  | `integer`  | Database port: 27017                                                               |
-| `mongodb`.`path`                             | `string`   | Directory to save the generated files: './src/**typegen**/mongodb'                 |
-| `mongodb`.`experimentals`                    | `object`   | Experimental features for MongoDB: {}                                              |
-| `mongodb`.`experimentals`.`strict`           | `boolean`  | Strict schema and typings: true or false                                           |
+| Key                                          | Type                  | Description                                                                        |
+| -------------------------------------------- | --------------------- | ---------------------------------------------------------------------------------- |
+| `architecture`                               | `string`              | Programming style: 'class' or 'functional'.                                        |
+| `format`                                     | `string`              | Naming Convention 'camelCase' or 'snake_case'.                                     |
+| `experimentalResolvers`                      | `boolean`             | Creates methods for every table columns: true or false                             |
+| `prettier`                                   | `boolean`             | Format generated code: true or false                                               |
+| `splitTypings`                               | `boolean`             | Abstract types and interfaces in the `types.ts` file: true or false                |
+| `postgresql`                                 | `object`              | PostgreSQL database configuration.                                                 |
+| `postgresql`.`schemas` (New v1.1)            | `string[]`            | Specific schema to generate: ["table_one", "table_two"]                            |
+| `postgresql`.`dbConfig`                      | `object`              | Configuration settings for PostgreSQL database connection: {}                      |
+| `postgresql`.`dbConfig`.`user`               | `string`              | Database user: 'postgres'                                                          |
+| `postgresql`.`dbConfig`.`host`               | `string`              | Database host: 'localhost'                                                         |
+| `postgresql`.`dbConfig`.`database`           | `string`              | Database name: ''                                                                  |
+| `postgresql`.`dbConfig`.`password`           | `string`              | Database password: 'password'                                                      |
+| `postgresql`.`dbConfig`.`port`               | `integer`             | Database port: 5432                                                                |
+| `postgresql`.`path`                          | `string`              | Directory to save the generated files: './src/**typegen**/postgresql'              |
+| `postgresql`.`experimentals`                 | `object`              | Experimental features for PostgreSQL: {}                                           |
+| `postgresql`.`experimentals`.`relationships` | `boolean`             | Include tables constraints / relationships for the `select` methods: true or false |
+| `mongodb`                                    | `object` or `boolean` | MongoDB database configuration.                                                    |
+| `mongodb`.`dbConfig`                         | `object`              | Configuration settings for MongoDB database connection: {}                         |
+| `mongodb`.`dbConfig`.`host`                  | `string`              | Database host: 'localhost'                                                         |
+| `mongodb`.`dbConfig`.`database`              | `string`              | Database name: ''                                                                  |
+| `mongodb`.`dbConfig`.`port`                  | `integer`             | Database port: 27017                                                               |
+| `mongodb`.`path`                             | `string`              | Directory to save the generated files: './src/**typegen**/mongodb'                 |
+| `mongodb`.`experimentals`                    | `object`              | Experimental features for MongoDB: {}                                              |
+| `mongodb`.`experimentals`.`strict`           | `boolean`             | Strict schema and typings: true or false                                           |
 
 ## Usage
 
@@ -156,10 +156,25 @@ Table: users
 
 ## Changelog
 
+**1.1.7**
+
+- Added double quote delimiter for tables to avoid clashing with postgresql reserved words
+- Removed `insert`, `update` and `delete` client schema check
+- Improved `experimentalResolver` typings
+- Improved `relationships` resolvers return types
+- Improved `insert` statement return type
+  - Introduced `PGInsertResult<T> - { insertedCount: number; data: T[] }`
+- Improved `update` statement return type
+  - Introduced `PGUpdateResult<T> - { updatedCount: number; data: T[] }`
+- Improved `delete` statement return type
+  - Introduced `PGDeleteResult<T> - { deletedCount: number }`
+- Fixed `db-typegen-utils` import path
+- Fixed undefined error on generate
 
 **1.1.2**
+
 - Removed default query logging
-  - Though still shows when `FindOptionsPG.debug` is `true`
+  - Though still shows when `PGFindOptions.debug` is `true`
 - Fixed `experimentalResolver` methods `filter` args not working
   - Currently supports `=` by default
 
@@ -176,6 +191,6 @@ Table: users
 
 - Initial release
 
-
 ## Contributing
+
 Raise issue or pull request on: [https://github.com/chrischanF/db-typegen](https://github.com/chrischanF/db-typegen)

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,11 +53,11 @@ const main = async () => {
 
   const mesh = {
     postgresql: await psql(config),
-    mongodb: await mongod(config),
+    mongodb: typeof config?.mongodb === 'object' ? await mongod(config) : null,
   };
 
   for await (const [db, path] of Object.entries(outputs)) {
-    if (!mesh[db].code) continue;
+    if (!mesh[db]?.code) continue;
     if (!fs.existsSync(path)) {
       fs.mkdirSync(path, { recursive: true });
     }

--- a/src/lib/typegen/mongodb/generate.ts
+++ b/src/lib/typegen/mongodb/generate.ts
@@ -38,6 +38,7 @@ export default async function main(config: any) {
 }
 
 function createUtilImports() {
+  const importPath = process.env.NODE_ENV === 'development' ? `'../../../deps/db-typegen-utils/src'` : `'db-typegen-utils'`;
   return `
     import {
       mongodb,
@@ -48,7 +49,7 @@ function createUtilImports() {
       InsertOptions,
       UpdateOptions
     }
-    from 'db-typegen-utils';
+    from ${importPath};
  `;
 }
 

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "db-typegen",
-  "version": "1.1.2",
+  "version": "1.1.7",
   "description": "A typescript ORM code generator for database sources.",
   "author": {
     "name": "Christian Fernandez",
@@ -14,7 +14,7 @@
     "pg": "^8.13.0",
     "dotenv": "^16.4.5",
     "mongodb": "^6.10.0",
-    "db-typegen-utils": "^1.0.3",
+    "db-typegen-utils": "^1.0.7",
     "prettier": "^3.3.3"
   },
   "keywords": [


### PR DESCRIPTION
- Added double quote delimiter for tables to avoid clashing with postgresql reserved words
- Removed insert, update and delete client schema check
- Improved experimentalResolver typings
- Improved relationships resolvers return types
- Improved insert statement return type
- Introduced PGInsertResult<T> - { insertedCount: number; data: T[] }
- Improved update statement return type
- Introduced PGUpdateResult<T> - { updatedCount: number; data: T[] }
- Improved delete statement return type
- Introduced PGDeleteResult<T> - { deletedCount: number }
- Fixed db-typegen-utils import path
- Fixed undefined error on generate